### PR TITLE
ci: skip publish-report for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,8 @@ jobs:
       #     retention-days: 5
 
   publish-report:
-    if: ${{ always() && !cancelled() }}
+    # Skip for fork PRs (no write permissions for GITHUB_TOKEN)
+    if: ${{ always() && !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [playwright-tests]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration to ensure that the `publish-report` job only runs for pull requests originating from the main repository, preventing issues with forked PRs that lack write permissions.

* Updated the `publish-report` job condition in `.github/workflows/ci.yml` to skip execution for forked pull requests by checking that the PR's source repository matches the main repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to optimize report publishing for pull requests, with improved handling for forked repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->