### PR TITLE
use the personal access token for cp-update

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -3,7 +3,7 @@ name: Create Plugin Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1 * *' # run once a month on the 1st day
+    - cron: '0 0 1 */2 *' # run every two months on the 1st day
 
 # To use the default github token with the following elevated permissions make sure to check:
 # **Allow GitHub Actions to create and approve pull requests** in https://github.com/ORG_NAME/REPO_NAME/settings/actions.
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: grafana/plugin-actions/create-plugin-update@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for plugin updates. The main changes are to the scheduling frequency and authentication method for the workflow.

Workflow configuration updates:

* Changed the workflow schedule to run every two months on the 1st day, instead of every month. (`.github/workflows/cp-update.yml`)

Authentication changes:

* Updated the token used for plugin updates from the default `GITHUB_TOKEN` to a custom `GH_PAT_TOKEN` secret for improved permissions and security. (`.github/workflows/cp-update.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated update workflow schedule from monthly to bi-monthly and modified the authentication method used for updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->