### PR TITLE
Chore: bump the plugin version to 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.2.3](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.2.3)
+
+[Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.2.2...v1.2.3)
+
+- Enhancement: Change info levels to debug for all requests in the backend ([#118](https://github.com/hoptical/grafana-kafka-datasource/pull/118))
+
 ## [v1.2.2](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.2.2)
 
 [Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.2.1...v1.2.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamedkarbasi93-kafka-datasource",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Kafka Datasource Plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
         "path": "img/graph.gif"
       }
     ],
-    "version": "1.2.2",
+    "version": "1.2.3",
     "updated": "%TODAY%"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request prepares for the v1.2.3 release of the project and documents a backend logging enhancement. The main changes are version bumps across key files and an update to the changelog to reflect the latest improvement.

Release and documentation updates:

* Bumped the version to `1.2.3` in `package.json` and `src/plugin.json` to prepare for the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-3c1bbe21d50836befcccc2df86e0ceb27afbb4444eb924d015be9298df27604eL40-R40)
* Updated `CHANGELOG.md` to add a v1.2.3 section, noting that info-level logs for all backend requests are now set to debug level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.2.3
  * Updated changelog with new version information
  * Manifest files synchronized to reflect latest version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->