### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.3.0](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.3.0)
+
+[Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.2.3...v1.3.0)
+
+- Fix: Improve SASL defaulting, error clarity, and health check timeout handling ([#123](https://github.com/hoptical/grafana-kafka-datasource/pull/123))
+- Feat: Add support for `refid` and `alias` in queries ([#122](https://github.com/hoptical/grafana-kafka-datasource/pull/122))
+- Fix: Multiple query support by making streaming stateless ([#121](https://github.com/hoptical/grafana-kafka-datasource/pull/121))
+
 ## [v1.2.3](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.2.3)
 
 [Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.2.2...v1.2.3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamedkarbasi93-kafka-datasource",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Kafka Datasource Plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
         "path": "img/graph.gif"
       }
     ],
-    "version": "1.2.3",
+    "version": "1.3.0",
     "updated": "%TODAY%"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request releases version 1.3.0 of the Kafka Datasource Plugin, introducing several improvements and new features. Notably, it adds support for `refid` and `alias` in queries, enhances SASL handling and error messages, and improves support for multiple queries by making streaming stateless.

**Release updates:**

* Bumped version to `1.3.0` in `package.json` and `src/plugin.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-3c1bbe21d50836befcccc2df86e0ceb27afbb4444eb924d015be9298df27604eL40-R40)
* Updated `CHANGELOG.md` with details for v1.3.0, highlighting improvements to SASL defaulting, error clarity, health check timeout handling, support for `refid` and `alias` in queries, and improved multiple query support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for refid and alias in queries

* **Bug Fixes**
  * Improved SASL defaulting and error clarity
  * Improved health check timeout handling
  * Enhanced multiple query support with stateless streaming

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->