### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.5.0](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.5.0)
+
+[Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.4.0...v1.5.0)
+
+- Fix: cleanup Kafka connections, tighten logging, propagate context & use theme spacing in QueryEditor ([#133](https://github.com/hoptical/grafana-kafka-datasource/pull/133))
+- Feat: add support for json, string and binary message keys ([#132](https://github.com/hoptical/grafana-kafka-datasource/pull/132))
+
 ## [v1.4.0](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.4.0)
 
 [Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.3.0...v1.4.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamedkarbasi93-kafka-datasource",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Kafka Datasource Plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
         "path": "img/graph.gif"
       }
     ],
-    "version": "1.4.0",
+    "version": "1.5.0",
     "updated": "%TODAY%"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request prepares for the v1.5.0 release of the plugin, updating version numbers and the changelog to reflect recent enhancements and fixes. The main changes are version bumps and documentation updates.

Release and documentation updates:

* Bumped the version from `1.4.0` to `1.5.0` in `package.json` and `src/plugin.json` to mark the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-3c1bbe21d50836befcccc2df86e0ceb27afbb4444eb924d015be9298df27604eL40-R40)
* Updated `CHANGELOG.md` with v1.5.0 release notes, highlighting fixes for Kafka connection cleanup, logging improvements, context propagation, UI spacing, and new support for JSON, string, and binary message keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JSON, string, and binary message keys to enhance message handling capabilities

* **Bug Fixes**
  * Improved Kafka connection cleanup and management
  * Enhanced logging precision and context propagation
  * Refined theme spacing in QueryEditor for better UI presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->