### PR TITLE
Fix: demote idle partition poll timeouts from error to debug log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         name: golangci-lint-full
         description: Fast linters runner for Go. Runs on all files in the module.
         entry: golangci-lint run --fix
-        language: golang
+        language: system
         require_serial: true
         pass_filenames: false
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
   console:
     container_name: redpanda-console
     image: docker.redpanda.com/redpandadata/console:v2.8.5
-    restart: always
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml && echo "$$CONSOLE_ROLEBINDINGS_CONFIG_FILE" > /tmp/role-bindings.yml && /app/console'
     volumes:

--- a/pkg/plugin/stream_manager.go
+++ b/pkg/plugin/stream_manager.go
@@ -1081,6 +1081,14 @@ func (sm *StreamManager) readFromPartition(
 					continue
 				}
 
+				// Stream shutdown and query stop are expected and should not emit
+				// frontend error frames.
+				if errors.Is(err, context.Canceled) {
+					log.DefaultLogger.Debug("Partition reader canceled",
+						"partition", partition)
+					return
+				}
+
 				log.DefaultLogger.Error("Error reading from partition",
 					"partition", partition,
 					"error", err)

--- a/pkg/plugin/stream_manager.go
+++ b/pkg/plugin/stream_manager.go
@@ -1067,14 +1067,10 @@ func (sm *StreamManager) readFromPartition(
 			msgCancel() // Cancel immediately after use to avoid resource leaks in long-running loop
 
 			if err != nil {
-				log.DefaultLogger.Error("Error reading from partition",
-					"partition", partition,
-					"error", err)
-
 				// Check if it's a timeout error - if so, continue to next iteration
 				// to prevent stream from freezing
 				if errors.Is(err, context.DeadlineExceeded) {
-					log.DefaultLogger.Debug("Read timeout on partition, continuing to next iteration",
+					log.DefaultLogger.Debug("No new messages on partition, continuing to next iteration",
 						"partition", partition)
 					// Brief pause before retrying
 					select {
@@ -1084,6 +1080,10 @@ func (sm *StreamManager) readFromPartition(
 					}
 					continue
 				}
+
+				log.DefaultLogger.Error("Error reading from partition",
+					"partition", partition,
+					"error", err)
 
 				// Create an error message to send to the frontend
 				errorMsg := kafka_client.KafkaMessage{

--- a/pkg/plugin/stream_manager_test.go
+++ b/pkg/plugin/stream_manager_test.go
@@ -638,6 +638,50 @@ func TestStreamManager_readFromPartition_PullError(t *testing.T) {
 	}
 }
 
+func TestStreamManager_readFromPartition_PullContextCanceled(t *testing.T) {
+	mockClient := &mockStreamClient{
+		pullErr: context.Canceled,
+	}
+
+	sm := NewStreamManager(mockClient, 5, 1000)
+	qm := queryModel{
+		Topic:           "test-topic",
+		AutoOffsetReset: "earliest",
+		LastN:           10,
+		MessageFormat:   "json",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	messagesCh := make(chan messageWithPartition, 10)
+
+	config := &StreamConfig{
+		MessageFormat:   qm.MessageFormat,
+		AutoOffsetReset: qm.AutoOffsetReset,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sm.readFromPartition(ctx, 0, qm, config, messagesCh)
+	}()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected partition reader to stop promptly on context cancellation")
+	}
+
+	select {
+	case msg := <-messagesCh:
+		t.Fatalf("expected no error frame for context cancellation, got: %v", msg.msg.Error)
+	default:
+		// expected
+	}
+}
+
 func TestStreamManager_readFromPartition_ContextCancellation(t *testing.T) {
 	mockClient := &mockStreamClient{
 		pullMessages: []kafka_client.KafkaMessage{


### PR DESCRIPTION
This pull request includes several improvements and minor adjustments across configuration and logging in the project. The most significant changes involve refining error logging in the stream manager, updating linter configuration, and a small update to the Docker Compose setup.

**Logging improvements:**

* Refined error handling in `StreamManager`: Timeout errors are now logged as debug messages ("No new messages on partition..."), while other errors are logged as errors after the timeout check. This prevents unnecessary error logs for expected timeout behavior and ensures only unexpected errors are reported as errors. (`pkg/plugin/stream_manager.go`) [[1]](diffhunk://#diff-150943e3bd5791e47e6fc4a10f9f77841c8b437b6cd5f6c03508b697a8a9af08L1070-R1073) [[2]](diffhunk://#diff-150943e3bd5791e47e6fc4a10f9f77841c8b437b6cd5f6c03508b697a8a9af08R1084-R1087)

**Configuration updates:**

* Updated `golangci-lint` hook in `.pre-commit-config.yaml` to use `system` language instead of `golang`, likely improving compatibility with pre-commit environments. (`.pre-commit-config.yaml`)

**Docker Compose update:**

* Removed the `restart: always` directive from the `console` service in `docker-compose.yaml`, possibly to prevent automatic restarts during development or testing. (`docker-compose.yaml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook language configuration for development tooling

* **Bug Fixes**
  * Improved partition message-reading behavior and logging to distinguish timeouts and cancellations from real errors
  * Removed automatic restart policy from the console service in deployment configuration

* **Tests**
  * Added a test to verify partition reader stops cleanly on cancellation and does not emit an error frame
<!-- end of auto-generated comment: release notes by coderabbit.ai -->