### PR TITLE
tests: add retries to the e2e test in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
-        run: GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} pnpm run e2e
+        run: GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} pnpm run e2e --retries 3
 
       - name: Upload e2e test summary
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main


### PR DESCRIPTION
This pull request makes a minor improvement to the CI workflow by increasing the reliability of Playwright end-to-end tests. The change adds a retry mechanism to the test command, allowing tests to automatically retry up to three times in case of intermittent failures.

* CI workflow reliability:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL226-R226): Updated the Playwright test run step to include `--retries 3`, enabling up to three retries for failing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by adding automatic retries to the Playwright test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->