### PR TITLE
fix: address post-merge review findings on Line Protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Fix: address post-merge review findings on Line Protocol support (follow-up to [#146](https://github.com/hoptical/grafana-kafka-datasource/pull/146)):
+  - Fix a panic when a Line Protocol message ends in an unterminated quoted field value (e.g. `m f="`).
+  - Line Protocol measurement/field/tag filter entries that aren't valid regexes (e.g. a literal tag value like `+N01`) now fall back to an exact literal match instead of being silently dropped (which previously left the filter axis unconstrained).
+  - Tag keys that collide with a reserved column name (`Time`, `_measurement`, `_field`, `value`, `value_str`, `partition`, `offset`) are now renamed to `tag_<key>` so both columns remain readable.
+  - Line Protocol parse-error frames now share the same core schema (`Time`, `_measurement`, `_field`, `value`, `value_str`, tag columns, `offset`) as successfully parsed frames, plus an `error` column, so the Grafana Live channel schema no longer flips on a malformed message.
+  - The "Sent frames to Grafana" debug log no longer fires when every frame in a message failed to send.
+  - The per-stream Line Protocol tag-key set is now capped (reusing the existing flatten field cap) instead of growing unboundedly for the life of a stream.
+  - The compiled Line Protocol filter is now built once per stream and cached instead of being recompiled from regex on every message.
 - Feat: add InfluxDB Line Protocol support — streaming-friendly long-format frame (one row per LP field) with stable schema `Time | _measurement | _field | value | value_str | <one column per tag key> | partition? | offset`. The fixed schema lets Grafana Live append rows cleanly across messages, while `_measurement` / `_field` / tag columns let dashboards reproduce Influx-style per-series shape via the **Partition by values** transform. Per-query timestamp-precision selector (auto / ns / µs / ms / s).
 - Feat: per-query Line Protocol filters (measurement whitelist, field whitelist, tag `key=value` pairs). Non-matching lines/fields are dropped in the Go plugin after parsing and before frames are built, so high-cardinality topics narrow down to just the subset of data the panel needs.
 

--- a/pkg/plugin/lineprotocol_filter.go
+++ b/pkg/plugin/lineprotocol_filter.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"regexp"
 	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 type tagPattern struct {
@@ -116,9 +118,30 @@ func compileAnchored(pat string) (*regexp.Regexp, error) {
 	return regexp.Compile("^(?:" + pat + ")$")
 }
 
+// compileAnchoredOrLiteral compiles pat as an anchored regex. If pat isn't a
+// valid regex (e.g. "+N01", a literal tag value that happens to be an invalid
+// regex fragment), it falls back to an anchored literal exact-match via
+// regexp.QuoteMeta instead of silently dropping the entry — otherwise an axis
+// with zero surviving patterns matches everything, defeating the filter. A
+// warning is logged once per invalid pattern so operators can tell a raw
+// string was matched literally rather than as a regex.
+func compileAnchoredOrLiteral(pat string) *regexp.Regexp {
+	re, err := compileAnchored(pat)
+	if err == nil {
+		return re
+	}
+	log.DefaultLogger.Warn("lineprotocol filter pattern is not a valid regex; matching literally",
+		"pattern", pat,
+		"error", err)
+	// QuoteMeta escapes all regex metacharacters, so this compile cannot fail.
+	literal, _ := compileAnchored(regexp.QuoteMeta(pat))
+	return literal
+}
+
 // parseRegexpSet splits a comma-separated string into compiled regex patterns.
-// Each pattern is anchored, so plain entries become exact matches. Invalid
-// patterns are silently skipped. Returns nil when nothing useful remains.
+// Each pattern is anchored, so plain entries become exact matches. Patterns
+// that aren't valid regexes fall back to an anchored literal match (see
+// compileAnchoredOrLiteral). Returns nil when nothing useful remains.
 func parseRegexpSet(s string) []*regexp.Regexp {
 	if strings.TrimSpace(s) == "" {
 		return nil
@@ -129,17 +152,14 @@ func parseRegexpSet(s string) []*regexp.Regexp {
 		if p == "" {
 			continue
 		}
-		re, err := compileAnchored(p)
-		if err != nil {
-			continue
-		}
-		out = append(out, re)
+		out = append(out, compileAnchoredOrLiteral(p))
 	}
 	return out
 }
 
 // parseTagPatterns splits a comma-separated string of `key=value` pairs where
-// the value is treated as a regex pattern. Invalid patterns are silently skipped.
+// the value is treated as a regex pattern (falling back to a literal exact
+// match when it isn't a valid regex; see compileAnchoredOrLiteral).
 // Entries with a blank value (e.g. an interpolated-away `Building=`) are ignored
 // rather than compiled into `^(?:)$`, which would otherwise require the tag to be
 // empty and filter out every row.
@@ -158,11 +178,7 @@ func parseTagPatterns(s string) []tagPattern {
 		if k == "" || v == "" {
 			continue
 		}
-		re, err := compileAnchored(v)
-		if err != nil {
-			continue
-		}
-		out = append(out, tagPattern{key: k, value: re})
+		out = append(out, tagPattern{key: k, value: compileAnchoredOrLiteral(v)})
 	}
 	return out
 }

--- a/pkg/plugin/lineprotocol_filter_test.go
+++ b/pkg/plugin/lineprotocol_filter_test.go
@@ -207,6 +207,59 @@ func TestLineProtocolFilter_PlainEntryIsExactMatch(t *testing.T) {
 	}
 }
 
+// TestParseRegexpSet_InvalidRegexFallsBackToLiteralMatch is a regression test:
+// a filter entry that isn't a valid regex (e.g. "+N01", a real tag value from
+// testdata/lineprotocol/real_sample.txt) used to be silently dropped, which
+// left the axis unconstrained (matching everything) instead of filtering. It
+// must now fall back to an anchored literal exact-match instead.
+func TestParseRegexpSet_InvalidRegexFallsBackToLiteralMatch(t *testing.T) {
+	res := parseRegexpSet("+N01")
+	if len(res) != 1 {
+		t.Fatalf("want 1 compiled pattern (literal fallback), got %d", len(res))
+	}
+	if !res[0].MatchString("+N01") {
+		t.Errorf("literal fallback should match the raw string itself")
+	}
+	if res[0].MatchString("+N012") || res[0].MatchString("N01") {
+		t.Errorf("literal fallback must be an exact match, not a partial/substring match")
+	}
+}
+
+// TestParseTagPatterns_InvalidRegexFallsBackToLiteralMatch covers the same
+// fallback for the tag-filter axis (key=value pairs).
+func TestParseTagPatterns_InvalidRegexFallsBackToLiteralMatch(t *testing.T) {
+	patterns := parseTagPatterns("Site=+N01")
+	if len(patterns) != 1 {
+		t.Fatalf("want 1 tag pattern, got %d", len(patterns))
+	}
+	p := patterns[0]
+	if p.key != "Site" {
+		t.Errorf("key: want %q, got %q", "Site", p.key)
+	}
+	if !p.value.MatchString("+N01") {
+		t.Errorf("literal fallback should match the raw tag value exactly")
+	}
+	if p.value.MatchString("+N012") {
+		t.Errorf("literal fallback must be an exact match, not a prefix match")
+	}
+}
+
+// TestLineProtocolFilter_InvalidTagRegexStillFilters is an end-to-end
+// regression test for the real_sample.txt scenario: a Tag filter whose value
+// isn't a valid regex must still constrain the results (not silently match
+// everything).
+func TestLineProtocolFilter_InvalidTagRegexStillFilters(t *testing.T) {
+	frames := runFilterCase(t, &StreamConfig{
+		MessageFormat:                  "lineprotocol",
+		TimestampMode:                  "message",
+		LineProtocolTimestampPrecision: "s",
+		LineProtocolTags:               "Building=+NoSuchBuilding",
+	})
+	if len(frames) != 0 {
+		t.Errorf("invalid-regex tag filter with no matches should still filter everything out, got %d frames", len(frames))
+	}
+}
+
 // runFilterCase produces a frame from a fixed two-LP-line payload using the
 // given config. The payload has:
 //

--- a/pkg/plugin/lineprotocol_frame.go
+++ b/pkg/plugin/lineprotocol_frame.go
@@ -32,10 +32,7 @@ func (sm *StreamManager) ProcessMessageFrames(
 ) ([]*data.Frame, error) {
 	if config != nil && config.MessageFormat == "lineprotocol" {
 		if msg.Error != nil {
-			errFrame, err := createErrorFrame(msg, partition, partitions, msg.Error, config, topic)
-			if err != nil {
-				return nil, err
-			}
+			errFrame := sm.createLineProtocolErrorFrame(msg, partition, partitions, msg.Error, config, topic)
 			return []*data.Frame{errFrame}, nil
 		}
 		if len(msg.RawValue) == 0 {
@@ -53,10 +50,7 @@ func (sm *StreamManager) ProcessMessageFrames(
 			if len(parseErrs) > 0 {
 				cause = parseErrs[0]
 			}
-			errFrame, err := createErrorFrame(msg, partition, partitions, cause, config, topic)
-			if err != nil {
-				return nil, err
-			}
+			errFrame := sm.createLineProtocolErrorFrame(msg, partition, partitions, cause, config, topic)
 			return []*data.Frame{errFrame}, nil
 		}
 		return sm.buildLineProtocolFrames(msg, lines, partition, partitions, config, topic), nil
@@ -95,7 +89,7 @@ func (sm *StreamManager) buildLineProtocolFrames(
 	config *StreamConfig,
 	topic string,
 ) []*data.Frame {
-	filter := buildLineProtocolFilter(config)
+	filter := sm.getLineProtocolFilter(config)
 	if filter != nil {
 		lines = applyLineProtocolFilter(lines, filter)
 	}
@@ -179,7 +173,7 @@ func (sm *StreamManager) buildLineProtocolFrames(
 		data.NewField("value_str", nil, valueStrs),
 	)
 	for _, k := range tagKeys {
-		frame.Fields = append(frame.Fields, data.NewField(k, nil, tagCols[k]))
+		frame.Fields = append(frame.Fields, data.NewField(lpColumnName(k), nil, tagCols[k]))
 	}
 	if multiPartition {
 		frame.Fields = append(frame.Fields, data.NewField("partition", nil, partitions32))
@@ -187,6 +181,87 @@ func (sm *StreamManager) buildLineProtocolFrames(
 	frame.Fields = append(frame.Fields, data.NewField("offset", nil, offsets))
 
 	return []*data.Frame{frame}
+}
+
+// lpReservedColumns are the fixed, non-tag column names in a line-protocol
+// frame. A tag key that collides with one of these would otherwise produce
+// two same-named fields; data.Frame.FieldByName only returns the first,
+// silently making the tag's value unreachable to downstream consumers.
+var lpReservedColumns = map[string]struct{}{
+	"Time": {}, "_measurement": {}, "_field": {}, "value": {}, "value_str": {},
+	"partition": {}, "offset": {},
+}
+
+// lpColumnName maps a raw line-protocol tag key to its frame column name,
+// prefixing it with "tag_" when the raw key collides with one of the fixed
+// column names in lpReservedColumns.
+func lpColumnName(tagKey string) string {
+	if _, reserved := lpReservedColumns[tagKey]; reserved {
+		return "tag_" + tagKey
+	}
+	return tagKey
+}
+
+// getLineProtocolFilter returns the compiled line-protocol filter for this
+// stream, building it once from config and caching it thereafter. config is
+// immutable for the life of a stream (built once in RunStream), and
+// ProcessMessageFrames is only ever invoked from the single sequential
+// message-processing loop per stream, so no locking is required here—unlike
+// schemaCache, which multiple partition-reader goroutines can touch.
+func (sm *StreamManager) getLineProtocolFilter(config *StreamConfig) *lineProtocolFilter {
+	if !sm.lpFilterBuilt {
+		sm.lpFilter = buildLineProtocolFilter(config)
+		sm.lpFilterBuilt = true
+	}
+	return sm.lpFilter
+}
+
+// createLineProtocolErrorFrame builds a single-row error frame that shares the
+// same core schema as buildLineProtocolFrames (Time, _measurement, _field,
+// value, value_str, one column per tag key already known to this stream,
+// partition?, offset) plus an additional `error` string column. Keeping the
+// core schema compatible with the success-path frame avoids flipping Grafana
+// Live's channel schema between a malformed message and its well-formed
+// neighbors, which previously could reset or break the streaming panel.
+func (sm *StreamManager) createLineProtocolErrorFrame(
+	msg kafka_client.KafkaMessage,
+	partition int32,
+	partitions []int32,
+	cause error,
+	config *StreamConfig,
+	topic string,
+) *data.Frame {
+	multiPartition := len(partitions) > 1
+
+	frame := data.NewFrame("lineprotocol")
+	if config != nil {
+		if config.RefID != "" {
+			frame.RefID = config.RefID
+		}
+		if config.Alias != "" {
+			frame.Name = formatAlias(config.Alias, config, topic, partition, "")
+		}
+	}
+
+	frame.Fields = append(frame.Fields,
+		data.NewField("Time", nil, []time.Time{msg.Timestamp}),
+		data.NewField("_measurement", nil, []string{""}),
+		data.NewField("_field", nil, []string{""}),
+		data.NewField("value", nil, []*float64{nil}),
+		data.NewField("value_str", nil, []*string{nil}),
+	)
+	for _, k := range sm.lpTagKeyOrder {
+		frame.Fields = append(frame.Fields, data.NewField(lpColumnName(k), nil, []*string{nil}))
+	}
+	if multiPartition {
+		frame.Fields = append(frame.Fields, data.NewField("partition", nil, []int32{partition}))
+	}
+	frame.Fields = append(frame.Fields,
+		data.NewField("offset", nil, []int64{msg.Offset}),
+		data.NewField("error", nil, []string{cause.Error()}),
+	)
+
+	return frame
 }
 
 // mergeLPTagKeys folds the tag keys from the current message's lines into the
@@ -201,10 +276,23 @@ func (sm *StreamManager) buildLineProtocolFrames(
 func (sm *StreamManager) mergeLPTagKeys(lines []ParsedLine) []string {
 	for _, l := range lines {
 		for _, t := range l.Tags {
-			if _, ok := sm.lpTagKeys[t.Key]; !ok {
-				sm.lpTagKeys[t.Key] = struct{}{}
-				sm.lpTagKeyOrder = append(sm.lpTagKeyOrder, t.Key)
+			if _, ok := sm.lpTagKeys[t.Key]; ok {
+				continue
 			}
+			// Cap the tag-key union the same way flattenFieldCap bounds JSON
+			// flattening, so a high-cardinality/drifting-tag topic can't grow the
+			// frame schema (and StreamManager's memory) unboundedly for the life
+			// of a stream subscription.
+			if sm.flattenFieldCap > 0 && len(sm.lpTagKeyOrder) >= sm.flattenFieldCap {
+				if !sm.lpTagCapWarned {
+					log.DefaultLogger.Warn("lineprotocol tag-key cap reached; further tag keys will be dropped from the frame schema",
+						"cap", sm.flattenFieldCap)
+					sm.lpTagCapWarned = true
+				}
+				continue
+			}
+			sm.lpTagKeys[t.Key] = struct{}{}
+			sm.lpTagKeyOrder = append(sm.lpTagKeyOrder, t.Key)
 		}
 	}
 	keys := make([]string, len(sm.lpTagKeyOrder))

--- a/pkg/plugin/lineprotocol_frame.go
+++ b/pkg/plugin/lineprotocol_frame.go
@@ -247,6 +247,7 @@ func (sm *StreamManager) createLineProtocolErrorFrame(
 	topic string,
 ) *data.Frame {
 	multiPartition := len(partitions) > 1
+	errTime := resolveLineProtocolTimestamp(ParsedLine{}, config, msg.Timestamp, time.Now())
 
 	frame := data.NewFrame("lineprotocol")
 	if config != nil {
@@ -259,7 +260,7 @@ func (sm *StreamManager) createLineProtocolErrorFrame(
 	}
 
 	frame.Fields = append(frame.Fields,
-		data.NewField("Time", nil, []time.Time{msg.Timestamp}),
+		data.NewField("Time", nil, []time.Time{errTime}),
 		data.NewField("_measurement", nil, []string{""}),
 		data.NewField("_field", nil, []string{""}),
 		data.NewField("value", nil, []*float64{nil}),

--- a/pkg/plugin/lineprotocol_frame.go
+++ b/pkg/plugin/lineprotocol_frame.go
@@ -172,8 +172,9 @@ func (sm *StreamManager) buildLineProtocolFrames(
 		data.NewField("value", nil, values),
 		data.NewField("value_str", nil, valueStrs),
 	)
+	tagColumns := lpTagColumnNames(tagKeys)
 	for _, k := range tagKeys {
-		frame.Fields = append(frame.Fields, data.NewField(lpColumnName(k), nil, tagCols[k]))
+		frame.Fields = append(frame.Fields, data.NewField(tagColumns[k], nil, tagCols[k]))
 	}
 	if multiPartition {
 		frame.Fields = append(frame.Fields, data.NewField("partition", nil, partitions32))
@@ -189,17 +190,31 @@ func (sm *StreamManager) buildLineProtocolFrames(
 // silently making the tag's value unreachable to downstream consumers.
 var lpReservedColumns = map[string]struct{}{
 	"Time": {}, "_measurement": {}, "_field": {}, "value": {}, "value_str": {},
-	"partition": {}, "offset": {},
+	"partition": {}, "offset": {}, "error": {},
 }
 
-// lpColumnName maps a raw line-protocol tag key to its frame column name,
-// prefixing it with "tag_" when the raw key collides with one of the fixed
-// column names in lpReservedColumns.
-func lpColumnName(tagKey string) string {
-	if _, reserved := lpReservedColumns[tagKey]; reserved {
-		return "tag_" + tagKey
+// lpTagColumnNames maps raw line-protocol tag keys to unique frame column
+// names. It reserves fixed columns (including "error"), then for each tag key
+// prefixes with "tag_" until the name is unused. This prevents collisions like
+// "value" -> "tag_value" versus a raw "tag_value" key.
+func lpTagColumnNames(tagKeys []string) map[string]string {
+	used := make(map[string]struct{}, len(lpReservedColumns)+len(tagKeys))
+	for k := range lpReservedColumns {
+		used[k] = struct{}{}
 	}
-	return tagKey
+	out := make(map[string]string, len(tagKeys))
+	for _, raw := range tagKeys {
+		name := raw
+		for {
+			if _, exists := used[name]; !exists {
+				break
+			}
+			name = "tag_" + name
+		}
+		out[raw] = name
+		used[name] = struct{}{}
+	}
+	return out
 }
 
 // getLineProtocolFilter returns the compiled line-protocol filter for this
@@ -250,8 +265,9 @@ func (sm *StreamManager) createLineProtocolErrorFrame(
 		data.NewField("value", nil, []*float64{nil}),
 		data.NewField("value_str", nil, []*string{nil}),
 	)
+	tagColumns := lpTagColumnNames(sm.lpTagKeyOrder)
 	for _, k := range sm.lpTagKeyOrder {
-		frame.Fields = append(frame.Fields, data.NewField(lpColumnName(k), nil, []*string{nil}))
+		frame.Fields = append(frame.Fields, data.NewField(tagColumns[k], nil, []*string{nil}))
 	}
 	if multiPartition {
 		frame.Fields = append(frame.Fields, data.NewField("partition", nil, []int32{partition}))

--- a/pkg/plugin/lineprotocol_frame_test.go
+++ b/pkg/plugin/lineprotocol_frame_test.go
@@ -266,3 +266,58 @@ func TestBuildLineProtocolFrames_AutoPrecisionDetect(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildLineProtocolFrames_TagKeyCollisionWithReservedColumn is a
+// regression test: a tag key that collides with a reserved column name (e.g.
+// "value") used to overwrite/shadow that column since data.Frame.FieldByName
+// only returns the first match. The colliding tag must now be renamed to
+// "tag_<key>" so both columns remain independently readable.
+func TestBuildLineProtocolFrames_TagKeyCollisionWithReservedColumn(t *testing.T) {
+	parsed := []ParsedLine{{
+		Measurement:  "m",
+		Tags:         []TagKV{{"value", "abc"}},
+		Fields:       []FieldKV{{"f", float64(1)}},
+		Timestamp:    100,
+		HasTimestamp: true,
+	}}
+	cfg := &StreamConfig{MessageFormat: "lineprotocol", TimestampMode: "message", LineProtocolTimestampPrecision: "s"}
+
+	frames := buildFrames(t, kafka_client.KafkaMessage{}, parsed, 0, []int32{0}, cfg)
+	f := frames[0]
+
+	reservedValue := fieldByName(f, "value")
+	if reservedValue == nil {
+		t.Fatalf("missing reserved 'value' numeric column")
+	}
+	if got := floatPtrAt(reservedValue, 0); got == nil || *got != 1 {
+		t.Errorf("reserved 'value' column should hold the numeric field value, got %v", reservedValue.At(0))
+	}
+
+	tagValue := fieldByName(f, "tag_value")
+	if tagValue == nil {
+		t.Fatalf("expected colliding tag key 'value' to be renamed to 'tag_value'")
+	}
+	if got := strPtrAt(tagValue, 0); got == nil || *got != "abc" {
+		t.Errorf("tag_value column: want %q, got %v", "abc", tagValue.At(0))
+	}
+}
+
+// TestGetLineProtocolFilter_CachedAcrossCalls is a regression test: the
+// compiled filter used to be rebuilt from scratch (with fresh regexp.Compile
+// calls) on every message. It must now be built once per stream and reused.
+func TestGetLineProtocolFilter_CachedAcrossCalls(t *testing.T) {
+	sm := NewStreamManager(&mockStreamClient{}, 5, 1000)
+	cfg := &StreamConfig{
+		MessageFormat:            "lineprotocol",
+		LineProtocolMeasurements: "Breaker Data",
+	}
+
+	first := sm.getLineProtocolFilter(cfg)
+	second := sm.getLineProtocolFilter(cfg)
+	if first == nil {
+		t.Fatalf("expected a non-nil filter given a non-empty measurement filter")
+	}
+	if first != second {
+		t.Errorf("expected the cached filter pointer to be reused across calls, got different instances")
+	}
+}

--- a/pkg/plugin/lineprotocol_frame_test.go
+++ b/pkg/plugin/lineprotocol_frame_test.go
@@ -302,6 +302,19 @@ func TestBuildLineProtocolFrames_TagKeyCollisionWithReservedColumn(t *testing.T)
 	}
 }
 
+func TestLPTagColumnNames_AvoidsGeneratedNameCollisions(t *testing.T) {
+	names := lpTagColumnNames([]string{"value", "tag_value", "error"})
+	if got := names["value"]; got != "tag_value" {
+		t.Fatalf("value key: want %q, got %q", "tag_value", got)
+	}
+	if got := names["tag_value"]; got != "tag_tag_value" {
+		t.Fatalf("tag_value key: want %q, got %q", "tag_tag_value", got)
+	}
+	if got := names["error"]; got != "tag_error" {
+		t.Fatalf("error key: want %q, got %q", "tag_error", got)
+	}
+}
+
 // TestGetLineProtocolFilter_CachedAcrossCalls is a regression test: the
 // compiled filter used to be rebuilt from scratch (with fresh regexp.Compile
 // calls) on every message. It must now be built once per stream and reused.

--- a/pkg/plugin/lineprotocol_stream_test.go
+++ b/pkg/plugin/lineprotocol_stream_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -270,5 +271,82 @@ func TestProcessMessageFrames_FullRealPayload(t *testing.T) {
 	}
 	if !foundFirmware {
 		t.Errorf("expected to find 'Firmware revision' row")
+	}
+}
+
+// TestProcessMessageFrames_ErrorFrameSchemaCompatibleWithSuccessFrame is a
+// regression test: the line-protocol error frame used to have a completely
+// different schema (lowercase "time", no _measurement/_field/value/tag
+// columns) from the success-path frame. Both are sent on the same Grafana
+// Live channel, so a malformed message among valid ones used to flip the
+// channel's schema. The error frame must now share the same core columns
+// (name and type) as the success frame.
+func TestProcessMessageFrames_ErrorFrameSchemaCompatibleWithSuccessFrame(t *testing.T) {
+	sm := NewStreamManager(&mockStreamClient{}, 5, 1000)
+	cfg := &StreamConfig{MessageFormat: "lineprotocol", TimestampMode: "message", LineProtocolTimestampPrecision: "s"}
+
+	// A well-formed message first, establishing the 'host' tag-key schema.
+	good, err := sm.ProcessMessageFrames(
+		kafka_client.KafkaMessage{RawValue: []byte("m,host=h1 f=1 100\n"), Offset: 1, Timestamp: time.Now()},
+		0, []int32{0}, cfg, "topic",
+	)
+	if err != nil {
+		t.Fatalf("good message err: %v", err)
+	}
+
+	// Then a malformed message on the same stream.
+	bad, err := sm.ProcessMessageFrames(
+		kafka_client.KafkaMessage{RawValue: []byte("not line protocol #"), Offset: 2, Timestamp: time.Now()},
+		0, []int32{0}, cfg, "topic",
+	)
+	if err != nil {
+		t.Fatalf("bad message err: %v", err)
+	}
+	if len(bad) != 1 {
+		t.Fatalf("want 1 error frame, got %d", len(bad))
+	}
+
+	successFrame := good[0]
+	errorFrame := bad[0]
+
+	for _, want := range []string{"Time", "_measurement", "_field", "value", "value_str", "host", "offset"} {
+		sf := fieldByName(successFrame, want)
+		ef := fieldByName(errorFrame, want)
+		if sf == nil || ef == nil {
+			t.Fatalf("column %q missing from success frame (present=%v) or error frame (present=%v)", want, sf != nil, ef != nil)
+		}
+		if sf.Type() != ef.Type() {
+			t.Errorf("column %q type mismatch: success=%v error=%v", want, sf.Type(), ef.Type())
+		}
+	}
+	if fieldByName(errorFrame, "error") == nil {
+		t.Errorf("error frame should carry an 'error' column")
+	}
+}
+
+// TestProcessMessageFrames_TagKeyGrowthIsCapped is a regression test: the
+// stream-wide tag-key union used to grow unboundedly for the life of a
+// stream. It must now stop growing once flattenFieldCap distinct tag keys
+// have been seen.
+func TestProcessMessageFrames_TagKeyGrowthIsCapped(t *testing.T) {
+	const tagCap = 3
+	sm := NewStreamManager(&mockStreamClient{}, 5, tagCap)
+	cfg := &StreamConfig{MessageFormat: "lineprotocol", TimestampMode: "message", LineProtocolTimestampPrecision: "s"}
+
+	// Each message introduces a brand-new tag key so the union would grow
+	// unboundedly without a cap.
+	for i := 0; i < tagCap+5; i++ {
+		raw := []byte(fmt.Sprintf("m,tag%d=v f=1 100\n", i))
+		_, err := sm.ProcessMessageFrames(
+			kafka_client.KafkaMessage{RawValue: raw, Offset: int64(i), Timestamp: time.Now()},
+			0, []int32{0}, cfg, "topic",
+		)
+		if err != nil {
+			t.Fatalf("message %d err: %v", i, err)
+		}
+	}
+
+	if got := len(sm.lpTagKeyOrder); got != tagCap {
+		t.Errorf("tag-key union should be capped at %d, got %d", tagCap, got)
 	}
 }

--- a/pkg/plugin/lineprotocol_stream_test.go
+++ b/pkg/plugin/lineprotocol_stream_test.go
@@ -365,6 +365,28 @@ func TestProcessMessageFrames_ErrorFrameKeepsErrorTagDistinct(t *testing.T) {
 	}
 }
 
+func TestProcessMessageFrames_ErrorFrameRespectsTimestampModeNow(t *testing.T) {
+	sm := NewStreamManager(&mockStreamClient{}, 5, 1000)
+	cfg := &StreamConfig{MessageFormat: "lineprotocol", TimestampMode: "now", LineProtocolTimestampPrecision: "s"}
+
+	msgTs := time.Unix(123, 0)
+	frames, err := sm.ProcessMessageFrames(
+		kafka_client.KafkaMessage{RawValue: []byte("not line protocol #"), Offset: 2, Timestamp: msgTs},
+		0, []int32{0}, cfg, "topic",
+	)
+	if err != nil {
+		t.Fatalf("bad message err: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("want 1 error frame, got %d", len(frames))
+	}
+
+	got := frames[0].Fields[0].At(0).(time.Time)
+	if got.Equal(msgTs) {
+		t.Fatalf("TimestampMode=now should not use kafka timestamp; got %v", got)
+	}
+}
+
 // TestProcessMessageFrames_TagKeyGrowthIsCapped is a regression test: the
 // stream-wide tag-key union used to grow unboundedly for the life of a
 // stream. It must now stop growing once flattenFieldCap distinct tag keys

--- a/pkg/plugin/lineprotocol_stream_test.go
+++ b/pkg/plugin/lineprotocol_stream_test.go
@@ -324,6 +324,47 @@ func TestProcessMessageFrames_ErrorFrameSchemaCompatibleWithSuccessFrame(t *test
 	}
 }
 
+func TestProcessMessageFrames_ErrorFrameKeepsErrorTagDistinct(t *testing.T) {
+	sm := NewStreamManager(&mockStreamClient{}, 5, 1000)
+	cfg := &StreamConfig{MessageFormat: "lineprotocol", TimestampMode: "message", LineProtocolTimestampPrecision: "s"}
+
+	_, err := sm.ProcessMessageFrames(
+		kafka_client.KafkaMessage{RawValue: []byte("m,error=tagval f=1 100\n"), Offset: 1, Timestamp: time.Now()},
+		0, []int32{0}, cfg, "topic",
+	)
+	if err != nil {
+		t.Fatalf("good message err: %v", err)
+	}
+
+	bad, err := sm.ProcessMessageFrames(
+		kafka_client.KafkaMessage{RawValue: []byte("not line protocol #"), Offset: 2, Timestamp: time.Now()},
+		0, []int32{0}, cfg, "topic",
+	)
+	if err != nil {
+		t.Fatalf("bad message err: %v", err)
+	}
+	if len(bad) != 1 {
+		t.Fatalf("want 1 error frame, got %d", len(bad))
+	}
+
+	errorFrame := bad[0]
+	if fieldByName(errorFrame, "tag_error") == nil {
+		t.Fatalf("expected tag key 'error' to map to 'tag_error' column")
+	}
+	if fieldByName(errorFrame, "error") == nil {
+		t.Fatalf("expected dedicated error column")
+	}
+
+	seen := map[string]struct{}{}
+	for _, f := range errorFrame.Fields {
+		name := f.Name
+		if _, dup := seen[name]; dup {
+			t.Fatalf("duplicate field name in error frame: %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+}
+
 // TestProcessMessageFrames_TagKeyGrowthIsCapped is a regression test: the
 // stream-wide tag-key union used to grow unboundedly for the life of a
 // stream. It must now stop growing once flattenFieldCap distinct tag keys

--- a/pkg/plugin/lineprotocol_utils.go
+++ b/pkg/plugin/lineprotocol_utils.go
@@ -241,8 +241,14 @@ func classifyFieldValue(raw string) (interface{}, error) {
 		return nil, fmt.Errorf("empty value")
 	}
 	// Quoted string: readFieldValue keeps surrounding quotes to mark the type.
-	if raw[0] == '"' && raw[len(raw)-1] == '"' {
+	// Guard against a lone `"` (len 1): an unterminated quoted value at
+	// end-of-line would otherwise make raw[1:len(raw)-1] slice with low > high
+	// and panic.
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
 		return raw[1 : len(raw)-1], nil
+	}
+	if raw == `"` {
+		return nil, fmt.Errorf("unterminated quoted string %q", raw)
 	}
 	// Integer suffix.
 	if last := raw[len(raw)-1]; last == 'i' {

--- a/pkg/plugin/lineprotocol_utils.go
+++ b/pkg/plugin/lineprotocol_utils.go
@@ -195,6 +195,7 @@ func readFieldValue(b []byte, pos int) (raw string, term byte, end int, err erro
 	}
 	if b[pos] == '"' {
 		var sb strings.Builder
+		closed := false
 		// Mark this as a string field by re-prepending '"' so the classifier
 		// can distinguish "1" (string) from 1 (number).
 		sb.WriteByte('"')
@@ -214,12 +215,16 @@ func readFieldValue(b []byte, pos int) (raw string, term byte, end int, err erro
 			}
 			if c == '"' {
 				sb.WriteByte('"')
+				closed = true
 				i++
 				break
 			}
 			sb.WriteByte(c)
 		}
 		// After the closing quote, expect ',', ' ', or EOL.
+		if !closed {
+			return "", 0, i, fmt.Errorf("unterminated quoted string")
+		}
 		if i >= len(b) {
 			return sb.String(), 0, i, nil
 		}

--- a/pkg/plugin/lineprotocol_utils_test.go
+++ b/pkg/plugin/lineprotocol_utils_test.go
@@ -8,6 +8,34 @@ import (
 	"testing"
 )
 
+// TestClassifyFieldValue_UnterminatedQuoteDoesNotPanic is a regression test: a
+// field value that is a lone, unterminated quote at end-of-line (e.g. the
+// message `m f="`) used to panic with a slice-bounds-out-of-range error
+// instead of returning a parse error.
+func TestClassifyFieldValue_UnterminatedQuoteDoesNotPanic(t *testing.T) {
+	v, err := classifyFieldValue(`"`)
+	if err == nil {
+		t.Fatalf("want an error for an unterminated quoted value, got value=%v", v)
+	}
+}
+
+// TestParseLines_UnterminatedQuoteDoesNotPanic exercises the same case through
+// the full ParseLines entry point used by the streaming path.
+func TestParseLines_UnterminatedQuoteDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ParseLines panicked: %v", r)
+		}
+	}()
+	got, errs := ParseLines([]byte(`m f="`))
+	if len(got) != 0 {
+		t.Errorf("want 0 parsed lines for a malformed message, got %d", len(got))
+	}
+	if len(errs) == 0 {
+		t.Errorf("want a parse error for an unterminated quoted field value")
+	}
+}
+
 // TestParseLines_BasicSingleLine covers the simplest valid line.
 func TestParseLines_BasicSingleLine(t *testing.T) {
 	in := []byte(`weather,location=us field=82 1465839830100400200`)
@@ -213,20 +241,20 @@ func TestParseLines_RealPayload(t *testing.T) {
 	}
 	// All lines should share these tags.
 	wantTags := map[string]string{
-		"Building":          "DCM102",
-		"Dashboard":         "HiBreaker",
-		"Description":       "White space busbar",
-		"Device_tag":        "-XQ202",
-		"Equipment-tag":     "N01_DCM102_462_100_XQ202-id3-1",
-		"Floor":             "1",
-		"Full_tag":          "+N01_DCM102_=462.100_-XQ202",
+		"Building":           "DCM102",
+		"Dashboard":          "HiBreaker",
+		"Description":        "White space busbar",
+		"Device_tag":         "-XQ202",
+		"Equipment-tag":      "N01_DCM102_462_100_XQ202-id3-1",
+		"Floor":              "1",
+		"Full_tag":           "+N01_DCM102_=462.100_-XQ202",
 		"Gapit-product-code": "02/gapit-02-03-std.json",
-		"Module":            "207103",
-		"POD":               "X",
-		"POD_nr":            "POD207103",
-		"Site":              "+N01",
-		"System":            "=462.100",
-		"uid":               "ada72705-d21d-4dd0-aeac-459d47e88365",
+		"Module":             "207103",
+		"POD":                "X",
+		"POD_nr":             "POD207103",
+		"Site":               "+N01",
+		"System":             "=462.100",
+		"uid":                "ada72705-d21d-4dd0-aeac-459d47e88365",
 	}
 	gotTags := tagsToMap(first.Tags)
 	if !reflect.DeepEqual(gotTags, wantTags) {

--- a/pkg/plugin/lineprotocol_utils_test.go
+++ b/pkg/plugin/lineprotocol_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,16 @@ func TestParseLines_UnterminatedQuoteDoesNotPanic(t *testing.T) {
 	}
 	if len(errs) == 0 {
 		t.Errorf("want a parse error for an unterminated quoted field value")
+	}
+}
+
+func TestParseLines_UnterminatedQuotedContentReportsClearError(t *testing.T) {
+	_, errs := ParseLines([]byte(`m f="abc`))
+	if len(errs) == 0 {
+		t.Fatalf("want parse error for unterminated quoted content")
+	}
+	if !strings.Contains(errs[0].Error(), "unterminated quoted string") {
+		t.Fatalf("want unterminated quoted string error, got %q", errs[0].Error())
 	}
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -657,17 +657,17 @@ func (d *KafkaDatasource) RunStream(ctx context.Context, req *backend.RunStreamR
 
 	// Create new stream configuration
 	streamConfig := &StreamConfig{
-		MessageFormat:        qm.MessageFormat,
-		AvroSchemaSource:     qm.AvroSchemaSource,
-		AvroSchema:           qm.AvroSchema,
-		ProtobufSchemaSource: qm.ProtobufSchemaSource,
-		ProtobufSchema:       qm.ProtobufSchema,
-		AutoOffsetReset:      qm.AutoOffsetReset,
-		TimestampMode:        qm.TimestampMode,
-		LastN:                qm.LastN, // Added LastN to stream config
-		KeyFormat:            qm.KeyFormat,
-		RefID:                qm.RefID,
-		Alias:                qm.Alias,
+		MessageFormat:                  qm.MessageFormat,
+		AvroSchemaSource:               qm.AvroSchemaSource,
+		AvroSchema:                     qm.AvroSchema,
+		ProtobufSchemaSource:           qm.ProtobufSchemaSource,
+		ProtobufSchema:                 qm.ProtobufSchema,
+		AutoOffsetReset:                qm.AutoOffsetReset,
+		TimestampMode:                  qm.TimestampMode,
+		LastN:                          qm.LastN, // Added LastN to stream config
+		KeyFormat:                      qm.KeyFormat,
+		RefID:                          qm.RefID,
+		Alias:                          qm.Alias,
 		LineProtocolTimestampPrecision: qm.LineProtocolTimestampPrecision,
 		LineProtocolMeasurements:       qm.LineProtocolMeasurements,
 		LineProtocolFields:             qm.LineProtocolFields,
@@ -751,6 +751,7 @@ func (d *KafkaDatasource) RunStream(ctx context.Context, req *backend.RunStreamR
 				continue
 			}
 
+			sentCount := 0
 			for frameIdx, frame := range frames {
 				err = sender.SendFrame(frame, data.IncludeAll)
 				if err != nil {
@@ -761,13 +762,21 @@ func (d *KafkaDatasource) RunStream(ctx context.Context, req *backend.RunStreamR
 						"error", err)
 					continue
 				}
+				sentCount++
 			}
 
-			log.DefaultLogger.Debug("Sent frames to Grafana",
-				"messageNumber", messageCount,
-				"partition", msgWithPartition.partition,
-				"offset", msgWithPartition.msg.Offset,
-				"frameCount", len(frames))
+			// Only log success when at least one frame actually made it to Grafana;
+			// otherwise every SendFrame failure was already logged above as an
+			// error, and an unconditional success log here would mask a total
+			// send failure for this message.
+			if sentCount > 0 {
+				log.DefaultLogger.Debug("Sent frames to Grafana",
+					"messageNumber", messageCount,
+					"partition", msgWithPartition.partition,
+					"offset", msgWithPartition.msg.Offset,
+					"sentCount", sentCount,
+					"frameCount", len(frames))
+			}
 		}
 	}
 }

--- a/pkg/plugin/stream_manager.go
+++ b/pkg/plugin/stream_manager.go
@@ -29,6 +29,9 @@ type StreamManager struct {
 	fieldBuilder         *FieldBuilder                      // Maintains type registry across messages
 	lpTagKeys            map[string]struct{}                // Union of line-protocol tag keys seen across messages (schema stability)
 	lpTagKeyOrder        []string                           // Tag keys in first-seen order, so frame columns keep a stable position
+	lpTagCapWarned       bool                               // Guards a one-time warning once the tag-key cap (flattenFieldCap) is reached
+	lpFilter             *lineProtocolFilter                // Cached compiled line-protocol filter (built once per stream, see getLineProtocolFilter)
+	lpFilterBuilt        bool                               // Whether lpFilter has been built yet (nil is a valid "no filter" cache value)
 	schemaCache          map[string]string                  // Cache for schemas by subject name
 	schemaRegistryClient *kafka_client.SchemaRegistryClient // Cached Schema Registry client
 	mu                   sync.RWMutex


### PR DESCRIPTION
Follow-up to #146. Fixes 7 issues from hoptical's post-merge review:

- Fix panic on unterminated quoted field value at end-of-line (classifyFieldValue).
- Fall back to literal exact-match when a filter pattern isn't a valid regex, instead of silently dropping it and leaving the axis unconstrained.
- Rename tag columns that collide with reserved frame column names (e.g. a tag literally named "value") to tag_<key>.
- Give the Line Protocol error frame the same core schema as the success frame (Time/_measurement/_field/value/value_str/tag cols/ offset) plus an error column, so the Grafana Live channel schema no longer flips on a malformed message.
- Stop logging "Sent frames to Grafana" when every SendFrame call for a message failed.
- Cap the per-stream Line Protocol tag-key union (reusing flattenFieldCap) instead of growing it unboundedly.
- Cache the compiled Line Protocol filter per stream instead of recompiling every message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when processing unterminated quoted values.
  * Invalid filter patterns now fall back to exact literal matching.
  * Renamed tag columns that conflict with reserved column names.
  * Error frames now use a schema compatible with successful frames.
  * Suppressed misleading success logs when frame delivery fails.
  * Limited the number of tag columns generated per stream.
* **Performance**
  * Reused compiled Line Protocol filters across messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->