### PR TITLE
tests: add column and data checker for line protocol e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 [Full Changelog](https://github.com/hoptical/grafana-kafka-datasource/compare/v1.6.0...v1.7.0)
 
-- Feat: add InfluxDB Line Protocol support; streaming-friendly long-format frame (one row per LP field) with stable schema `Time | _measurement | _field | value | value_str | <one column per tag key> | partition? | offset`, per-query timestamp precision (auto / ns / µs / ms / s), and Line Protocol filters for measurement, field, and tags in the query editor ([#146](https://github.com/hoptical/grafana-kafka-datasource/pull/146)).
-- Chore: pin Grafana plugin CI actions to versioned releases, add `mise.toml` tool versions, and improve e2e selector stability across Grafana/UI variants ([#147](https://github.com/hoptical/grafana-kafka-datasource/pull/147)).
-- Test: add Playwright retry support in CI (`--retries 3`) to reduce flaky e2e failures ([#148](https://github.com/hoptical/grafana-kafka-datasource/pull/148)).
-- Fix: address post-merge Line Protocol issues (panic on unterminated quoted values, invalid-regex fallback to literal match, reserved-column tag-key collisions, error-frame schema compatibility, tag-key cap, and per-stream filter caching) ([#149](https://github.com/hoptical/grafana-kafka-datasource/pull/149)).
+- Feat: add InfluxDB Line Protocol support; streaming-friendly long-format frame (one row per LP field) with stable schema `Time | _measurement | _field | value | value_str | <one column per tag key> | partition? | offset`, per-query timestamp precision (auto / ns / µs / ms / s), and Line Protocol filters for measurement, field, and tags in the query editor ([#146](https://github.com/hoptical/grafana-kafka-datasource/pull/146))
+- Chore: pin Grafana plugin CI actions to versioned releases, add `mise.toml` tool versions, and improve e2e selector stability across Grafana/UI variants ([#147](https://github.com/hoptical/grafana-kafka-datasource/pull/147))
+- Test: add Playwright retry support in CI (`--retries 3`) to reduce flaky e2e failures ([#148](https://github.com/hoptical/grafana-kafka-datasource/pull/148))
+- Fix: address post-merge Line Protocol issues (panic on unterminated quoted values, invalid-regex fallback to literal match, reserved-column tag-key collisions, error-frame schema compatibility, tag-key cap, and per-stream filter caching) ([#149](https://github.com/hoptical/grafana-kafka-datasource/pull/149))
+- Feat: update changelog and upgrade dependencies to address security issues ([#150](https://github.com/hoptical/grafana-kafka-datasource/pull/150))
+- Tests: add column and data checker for line protocol e2e tests ([#151](https://github.com/hoptical/grafana-kafka-datasource/pull/151))
 
 ## [v1.6.0](https://github.com/hoptical/grafana-kafka-datasource/tree/v1.6.0)
 

--- a/example/go/producer.go
+++ b/example/go/producer.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -100,6 +101,34 @@ func waitForTopicLeaders(brokerURL, topic string, partitions int, timeout time.D
 	}
 }
 
+func buildLineProtocolMessage(counter int, hostName, hostIP string) []byte {
+	timestamp := time.Now().Unix()
+	breakerClosed := "true"
+	if counter%2 != 0 {
+		breakerClosed = "false"
+	}
+
+	lines := []string{
+		fmt.Sprintf(
+			"Breaker\\ Data,Building=DCM102,Dashboard=HiBreaker,Description=White\\ space\\ busbar,Device_tag=-XQ202,Equipment-tag=N01_DCM102_462_100_XQ202-id3-1,Floor=1,Full_tag=+N01_DCM102_\\=462.100_-XQ202,Gapit-product-code=02/gapit-02-03-std.json,Module=207103,POD=X,POD_nr=POD207103,Site=+N01,System=\\=462.100,uid=ada72705-d21d-4dd0-aeac-459d47e88365 PT\\ Primary=46.37,Circuit\\ breaker\\ closed=%s,Firmware\\ revision=\"XXXXXX\",Voltage\\ L-L\\ Average=10.154107093811035 %d",
+			breakerClosed,
+			timestamp,
+		),
+		fmt.Sprintf(
+			"Last\\ Trip,Building=DCM102,Dashboard=HiBreaker,Description=White\\ space\\ busbar,Device_tag=-XQ202,Equipment-tag=N01_DCM102_462_100_XQ202-id3-1,Floor=1,Full_tag=+N01_DCM102_\\=462.100_-XQ202,Gapit-product-code=02/gapit-02-03-std.json,Module=207103,POD=X,POD_nr=POD207103,Site=+N01,System=\\=462.100,uid=ada72705-d21d-4dd0-aeac-459d47e88365 Last\\ trip\\ event\\ Timestamp=4523548585i,Last\\ trip\\ event\\ code=29676i,Main\\ capability\\ of\\ device=\"MAIN_CAP\",Quality\\ Bit\\ Last\\ trip\\ event\\ origin\\ Electrical\\ fault\\ on\\ neutral=1i %d",
+			timestamp,
+		),
+		fmt.Sprintf(
+			"Measurement\\ Settings,host_name=%s,host_ip=%s Current\\ demand\\ calculation=53232i,Energy\\ accumulation\\ mode=24373i,Power\\ demand\\ calculation=25117i %d",
+			hostName,
+			hostIP,
+			timestamp,
+		),
+	}
+
+	return []byte(strings.Join(lines, "\n") + "\n")
+}
+
 func main() {
 	// Define command line flags with default values
 	brokerURL := flag.String("broker", "localhost:9094", "Kafka broker URL")
@@ -120,8 +149,8 @@ func main() {
 	flag.Parse()
 
 	// Validate format
-	if *format != "json" && *format != "avro" && *format != "protobuf" {
-		fmt.Printf("Error: Invalid format %q. Valid options: json, avro, protobuf\n", *format)
+	if *format != "json" && *format != "avro" && *format != "protobuf" && *format != "lineprotocol" {
+		fmt.Printf("Error: Invalid format %q. Valid options: json, avro, protobuf, lineprotocol\n", *format)
 		os.Exit(1)
 	}
 
@@ -183,141 +212,147 @@ func main() {
 	hostIP := "127.0.0.1"
 
 	for {
-		// Create sample data (flat, nested, or list)
-		// Periodically set value1/value2 to null to reproduce the bug.
-		rawValue1 := *valuesOffset - rand.Float64()
-		rawValue2 := *valuesOffset + rand.Float64()
-		var value1 interface{} = rawValue1
-		var value2 interface{} = rawValue2
-		if counter%7 == 0 {
-			value1 = nil
-		}
-		if counter%11 == 0 {
-			value2 = nil
-		}
-
 		var messageData []byte
 		var err error
-
-		// Create payload based on shape
-		var payload interface{}
-		switch *shape {
-		case "flat":
-			// Use appropriate field names based on format
-			if *format == "avro" || *format == "protobuf" {
-				// Avro requires valid field names (no dots)
-				payload = map[string]interface{}{
-					"host_name":        hostName,
-					"host_ip":          hostIP,
-					"metrics_cpu_load": value1,
-					"metrics_cpu_temp": 60.0 + rand.Float64()*10.0,
-					"metrics_mem_used": 1000 + rand.Intn(2000),
-					"metrics_mem_free": 8000 + rand.Intn(2000),
-					"value1":           value1,
-					"value2":           value2,
-					"tags":             []string{"prod", "edge"},
-				}
-			} else {
-				// JSON can use dotted field names
-				payload = map[string]interface{}{
-					"host.name":        hostName,
-					"host.ip":          hostIP,
-					"metrics.cpu.load": value1,
-					"metrics.cpu.temp": 60.0 + rand.Float64()*10.0,
-					"metrics.mem.used": 1000 + rand.Intn(2000),
-					"metrics.mem.free": 8000 + rand.Intn(2000),
-					"value1":           value1,
-					"value2":           value2,
-					"tags":             []string{"prod", "edge"},
-				}
-			}
-		case "nested":
-			payload = map[string]interface{}{
-				"host": map[string]interface{}{
-					"name": hostName,
-					"ip":   hostIP,
-				},
-				"metrics": map[string]interface{}{
-					"cpu": map[string]interface{}{
-						"load": value1,
-						"temp": 60.0 + rand.Float64()*10.0,
-					},
-					"mem": map[string]interface{}{
-						"used": 1000 + rand.Intn(2000),
-						"free": 8000 + rand.Intn(2000),
-					},
-				},
-				"value1": value1,
-				"value2": value2,
-				"tags":   []string{"prod", "edge"},
-				"alerts": []interface{}{
-					map[string]interface{}{
-						"type":     "cpu_high",
-						"severity": "warning",
-						"value":    rawValue1 * 100,
-					},
-					map[string]interface{}{
-						"type":     "mem_low",
-						"severity": "info",
-						"value":    rawValue2 * 50,
-					},
-				},
-				"processes": []string{"nginx", "mysql", "redis"},
-			}
-		case "list":
-			// Top-level array of records
-			payload = []interface{}{
-				map[string]interface{}{
-					"id":   counter,
-					"type": "metric",
-					"host": map[string]interface{}{
-						"name": hostName,
-						"ip":   hostIP,
-					},
-					"value":     value1,
-					"timestamp": time.Now().Unix(),
-				},
-				map[string]interface{}{
-					"id":   counter + 1,
-					"type": "metric",
-					"host": map[string]interface{}{
-						"name": hostName,
-						"ip":   hostIP,
-					},
-					"value":     value2,
-					"timestamp": time.Now().Unix(),
-				},
-				map[string]interface{}{
-					"id":   counter + 1000,
-					"type": "event",
-					"host": map[string]interface{}{
-						"name": hostName,
-						"ip":   hostIP,
-					},
-					"message":   "Sample log entry",
-					"timestamp": time.Now().Unix(),
-				},
-			}
-		default:
-			// Handle unknown shape
-			fmt.Printf("Error: Unknown shape %q. Valid options: nested, flat, list\n", *shape)
-			os.Exit(1)
-		}
-
-		// Encode based on format
-		switch *format {
-		case "json":
-			messageData, err = json.Marshal(payload)
-		case "avro":
+		if *format == "lineprotocol" {
 			if *verbose {
-				fmt.Printf("[PRODUCER DEBUG] Using Avro format for message #%d\n", counter)
+				fmt.Printf("[PRODUCER DEBUG] Using Line Protocol format for message #%d\n", counter)
 			}
-			messageData, err = EncodeAvroMessage(*shape, payload, *schemaRegistryURL, *schemaRegistryUser, *schemaRegistryPass, *topic, *verbose)
-		case "protobuf":
-			if *verbose {
-				fmt.Printf("[PRODUCER DEBUG] Using Protobuf format for message #%d\n", counter)
+			messageData = buildLineProtocolMessage(counter, hostName, hostIP)
+		} else {
+			// Create sample data (flat, nested, or list)
+			// Periodically set value1/value2 to null to reproduce the bug.
+			rawValue1 := *valuesOffset - rand.Float64()
+			rawValue2 := *valuesOffset + rand.Float64()
+			var value1 interface{} = rawValue1
+			var value2 interface{} = rawValue2
+			if counter%7 == 0 {
+				value1 = nil
 			}
-			messageData, err = EncodeProtobufMessage(*shape, payload, *schemaRegistryURL, *schemaRegistryUser, *schemaRegistryPass, *topic, *verbose)
+			if counter%11 == 0 {
+				value2 = nil
+			}
+
+			// Create payload based on shape
+			var payload interface{}
+			switch *shape {
+			case "flat":
+				// Use appropriate field names based on format
+				if *format == "avro" || *format == "protobuf" {
+					// Avro requires valid field names (no dots)
+					payload = map[string]interface{}{
+						"host_name":        hostName,
+						"host_ip":          hostIP,
+						"metrics_cpu_load": value1,
+						"metrics_cpu_temp": 60.0 + rand.Float64()*10.0,
+						"metrics_mem_used": 1000 + rand.Intn(2000),
+						"metrics_mem_free": 8000 + rand.Intn(2000),
+						"value1":           value1,
+						"value2":           value2,
+						"tags":             []string{"prod", "edge"},
+					}
+				} else {
+					// JSON can use dotted field names
+					payload = map[string]interface{}{
+						"host.name":        hostName,
+						"host.ip":          hostIP,
+						"metrics.cpu.load": value1,
+						"metrics.cpu.temp": 60.0 + rand.Float64()*10.0,
+						"metrics.mem.used": 1000 + rand.Intn(2000),
+						"metrics.mem.free": 8000 + rand.Intn(2000),
+						"value1":           value1,
+						"value2":           value2,
+						"tags":             []string{"prod", "edge"},
+					}
+				}
+			case "nested":
+				payload = map[string]interface{}{
+					"host": map[string]interface{}{
+						"name": hostName,
+						"ip":   hostIP,
+					},
+					"metrics": map[string]interface{}{
+						"cpu": map[string]interface{}{
+							"load": value1,
+							"temp": 60.0 + rand.Float64()*10.0,
+						},
+						"mem": map[string]interface{}{
+							"used": 1000 + rand.Intn(2000),
+							"free": 8000 + rand.Intn(2000),
+						},
+					},
+					"value1": value1,
+					"value2": value2,
+					"tags":   []string{"prod", "edge"},
+					"alerts": []interface{}{
+						map[string]interface{}{
+							"type":     "cpu_high",
+							"severity": "warning",
+							"value":    rawValue1 * 100,
+						},
+						map[string]interface{}{
+							"type":     "mem_low",
+							"severity": "info",
+							"value":    rawValue2 * 50,
+						},
+					},
+					"processes": []string{"nginx", "mysql", "redis"},
+				}
+			case "list":
+				// Top-level array of records
+				payload = []interface{}{
+					map[string]interface{}{
+						"id":   counter,
+						"type": "metric",
+						"host": map[string]interface{}{
+							"name": hostName,
+							"ip":   hostIP,
+						},
+						"value":     value1,
+						"timestamp": time.Now().Unix(),
+					},
+					map[string]interface{}{
+						"id":   counter + 1,
+						"type": "metric",
+						"host": map[string]interface{}{
+							"name": hostName,
+							"ip":   hostIP,
+						},
+						"value":     value2,
+						"timestamp": time.Now().Unix(),
+					},
+					map[string]interface{}{
+						"id":   counter + 1000,
+						"type": "event",
+						"host": map[string]interface{}{
+							"name": hostName,
+							"ip":   hostIP,
+						},
+						"message":   "Sample log entry",
+						"timestamp": time.Now().Unix(),
+					},
+				}
+			default:
+				// Handle unknown shape
+				fmt.Printf("Error: Unknown shape %q. Valid options: nested, flat, list\n", *shape)
+				os.Exit(1)
+			}
+
+			// Encode based on format
+			switch *format {
+			case "json":
+				messageData, err = json.Marshal(payload)
+			case "avro":
+				if *verbose {
+					fmt.Printf("[PRODUCER DEBUG] Using Avro format for message #%d\n", counter)
+				}
+				messageData, err = EncodeAvroMessage(*shape, payload, *schemaRegistryURL, *schemaRegistryUser, *schemaRegistryPass, *topic, *verbose)
+			case "protobuf":
+				if *verbose {
+					fmt.Printf("[PRODUCER DEBUG] Using Protobuf format for message #%d\n", counter)
+				}
+				messageData, err = EncodeProtobufMessage(*shape, payload, *schemaRegistryURL, *schemaRegistryUser, *schemaRegistryPass, *topic, *verbose)
+			}
 		}
 
 		if err != nil {

--- a/example/go/producer.go
+++ b/example/go/producer.go
@@ -139,7 +139,7 @@ func main() {
 	connectTimeout := flag.Int("connect-timeout", 5000, "Broker connect timeout in milliseconds")
 	leaderWaitTimeout := flag.Int("leader-wait-timeout", 30000, "Timeout in milliseconds to wait for topic leader election")
 	shape := flag.String("shape", "nested", "Payload shape: nested, flat, or list")
-	format := flag.String("format", "json", "Message format: json, avro, or protobuf")
+	format := flag.String("format", "json", "Message format: json, avro, protobuf, or lineprotocol")
 	schemaRegistryURL := flag.String("schema-registry", "", "Schema registry URL (for Avro/Protobuf with schema registry)")
 	schemaRegistryUser := flag.String("schema-registry-user", "", "Schema registry username (optional)")
 	schemaRegistryPass := flag.String("schema-registry-pass", "", "Schema registry password (optional)")

--- a/tests/queryEditor-avro.spec.ts
+++ b/tests/queryEditor-avro.spec.ts
@@ -9,6 +9,7 @@ import {
   setTableVisualization,
   openPartitionSelector,
   selectAllPartitionsOption,
+  selectMessageFormat,
 } from './test-utils';
 
 interface AvroProducerOptions {
@@ -91,44 +92,8 @@ function startTransactionalAvroKafkaProducer(topic: string): {
   });
 }
 
-async function findMessageFormatSelector(page: Page): Promise<Locator | null> {
-  const messageFormatApproaches = [
-    page
-      .locator('div')
-      .filter({ hasText: /^JSON$/ })
-      .nth(2), // The intercepting parent element
-    page.getByText('JSON').locator('../..'), // Go up two levels to find clickable parent
-    page.locator('.css-1eu65zc').filter({ hasText: /JSON/ }), // Direct selection of intercepting element
-    page.getByText('JSON').filter({ hasText: /^JSON$/ }), // Original approach
-    page.locator('button').filter({ hasText: /^JSON$/ }), // Button with exact JSON text
-    page.getByText('Message Format').locator('..').locator('button').first(), // Button near Message Format label
-    page.locator('[data-testid*="select"]'), // Any element with select in testid
-  ];
-
-  for (let i = 0; i < messageFormatApproaches.length; i++) {
-    const approach = messageFormatApproaches[i];
-    if (await approach.isVisible({ timeout: 1000 })) {
-      console.log(`Message format selector found using approach ${i}: ${approach.toString()}`);
-      return approach;
-    }
-  }
-  return null;
-}
-
 async function selectAvroMessageFormat(page: Page): Promise<void> {
-  // Wait for the page to stabilize after filling topic name
-  await expect(page.getByText('Message Format')).toBeVisible({ timeout: 5000 });
-
-  console.log('Looking for Message Format selector among buttons...');
-
-  const foundSelector = await findMessageFormatSelector(page);
-
-  // Message format selector MUST be found for Avro tests
-  expect(foundSelector).not.toBeNull();
-
-  // Click the message format selector
-  await foundSelector!.first().click();
-  await page.getByText('Avro').click();
+  await selectMessageFormat(page, 'Avro');
 }
 
 function getAvroSchemaSourceLocator(page: Page): Locator {

--- a/tests/queryEditor-lineprotocol.spec.ts
+++ b/tests/queryEditor-lineprotocol.spec.ts
@@ -1,7 +1,148 @@
-import { test, expect } from '@grafana/plugin-e2e';
-import { setTableVisualization } from './test-utils';
+/// <reference types="node" />
 
-test.describe('Kafka Query Editor - Line Protocol Tests', () => {
+import { test, expect } from '@grafana/plugin-e2e';
+import { Locator, Page } from '@playwright/test';
+import { ChildProcess, spawn } from 'child_process';
+import { accessSync, constants } from 'fs';
+import {
+  openPartitionSelector,
+  selectAllPartitionsOption,
+  setTableVisualization,
+  verifyPanelDataContains,
+  verifyColumnHeadersVisible,
+} from './test-utils';
+
+type ProducerHandle = {
+  producer: ChildProcess;
+  exitPromise: Promise<void>;
+};
+
+function startLineProtocolKafkaProducer(topic: string): ProducerHandle {
+  const producerPath = './dist/producer';
+  try {
+    accessSync(producerPath, constants.X_OK);
+  } catch (err) {
+    throw new Error(`Kafka producer executable not found or not executable at path: ${producerPath}`);
+  }
+
+  const args = [
+    '-broker',
+    'localhost:9094',
+    '-topic',
+    topic,
+    '-connect-timeout',
+    '5000',
+    '-num-partitions',
+    '3',
+    '-interval',
+    '300',
+    '-format',
+    'lineprotocol',
+    '-key-format',
+    'none',
+  ];
+
+  const producer = spawn(producerPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+  producer.stdout?.on('data', (data) => {
+    console.log('[Line Protocol Producer stdout]', data.toString());
+  });
+  producer.stderr?.on('data', (data) => {
+    console.error('[Line Protocol Producer stderr]', data.toString());
+  });
+
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    producer.on('error', (err) => reject(err));
+    producer.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Line Protocol Kafka producer exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  return { producer, exitPromise };
+}
+
+async function findMessageFormatSelector(page: Page): Promise<Locator | null> {
+  const messageFormatApproaches = [
+    page
+      .locator('div')
+      .filter({ hasText: /^JSON$/ })
+      .nth(2),
+    page.getByText('JSON').locator('../..'),
+    page.locator('.css-1eu65zc').filter({ hasText: /JSON/ }),
+    page.getByText('JSON').filter({ hasText: /^JSON$/ }),
+    page.locator('button').filter({ hasText: /^JSON$/ }),
+    page.getByText('Message Format').locator('..').locator('button').first(),
+    page.locator('[data-testid*="select"]'),
+  ];
+
+  for (const approach of messageFormatApproaches) {
+    if (await approach.isVisible({ timeout: 1000 })) {
+      return approach;
+    }
+  }
+
+  return null;
+}
+
+async function selectMessageFormat(page: Page, optionName: string): Promise<void> {
+  await expect(page.getByText('Message Format')).toBeVisible({ timeout: 5000 });
+
+  const foundSelector = await findMessageFormatSelector(page);
+  expect(foundSelector).not.toBeNull();
+
+  await foundSelector!.first().click();
+
+  const option = page
+    .getByLabel('Select options menu')
+    .getByText(optionName)
+    .or(page.getByRole('option', { name: optionName }));
+  await expect(option.first()).toBeVisible({ timeout: 5000 });
+  await option.first().click();
+}
+
+async function findTimestampPrecisionSelector(page: Page): Promise<Locator | null> {
+  const selectorApproaches = [
+    page.getByText('Timestamp Precision').locator('..').locator('button').first(),
+    page
+      .getByRole('combobox')
+      .filter({ hasText: /Auto-detect|Nanoseconds|Microseconds|Milliseconds|Seconds/ })
+      .first(),
+    page
+      .locator('div')
+      .filter({ hasText: /^Auto-detect$/ })
+      .first(),
+  ];
+
+  for (const approach of selectorApproaches) {
+    if (await approach.isVisible({ timeout: 1000 })) {
+      return approach;
+    }
+  }
+
+  return null;
+}
+
+async function selectTimestampPrecision(page: Page, optionName: string): Promise<void> {
+  await expect(page.getByText('Timestamp Precision')).toBeVisible({ timeout: 5000 });
+
+  const selector = await findTimestampPrecisionSelector(page);
+  expect(selector).not.toBeNull();
+
+  await selector!.first().click();
+
+  const option = page
+    .getByLabel('Select options menu')
+    .getByText(optionName)
+    .or(page.getByRole('option', { name: optionName }));
+  await expect(option.first()).toBeVisible({ timeout: 5000 });
+  await option.first().click();
+}
+
+test.describe.serial('Kafka Query Editor - Line Protocol Tests', () => {
   test('should expose Line Protocol format and timestamp-precision selector', async ({
     readProvisionedDataSource,
     page,
@@ -15,68 +156,10 @@ test.describe('Kafka Query Editor - Line Protocol Tests', () => {
     // Fill a topic so the editor renders the format selector.
     await page.getByRole('textbox', { name: 'Enter topic name' }).fill(`lp-${Date.now()}`);
 
-    // Open the Message Format select.
-    const messageFormatSelector = page
-      .getByText('Message Format')
-      .locator('..')
-      .locator('button')
-      .first()
-      .or(
-        page
-          .getByRole('combobox')
-          .filter({ hasText: /JSON|Avro|Protobuf|Plaintext|Line Protocol/ })
-          .first()
-      )
-      .or(
-        page
-          .locator('div')
-          .filter({ hasText: /^JSON$/ })
-          .first()
-      );
-    await expect(messageFormatSelector.first()).toBeVisible({ timeout: 8000 });
-    await messageFormatSelector.first().click();
-
-    // Confirm the Line Protocol option exists in the dropdown.
-    const lineProtocolOption = page
-      .getByLabel('Select options menu')
-      .getByText('Line Protocol')
-      .or(page.getByRole('option', { name: /^Line Protocol$/ }));
-    await expect(lineProtocolOption.first()).toBeVisible({ timeout: 5000 });
-    await lineProtocolOption.first().click();
+    await selectMessageFormat(page, 'Line Protocol');
 
     // Selecting Line Protocol should reveal the Timestamp Precision selector.
-    await expect(page.getByText('Timestamp Precision')).toBeVisible({ timeout: 5000 });
-
-    // Switching precision should not throw — open the dropdown and pick Seconds.
-    // Grafana's <Select> renders the chosen value in a sibling <div>, not inside
-    // the combobox input, so the combobox hasText filter never matches. Fall back
-    // to the rendered value container, mirroring the Message Format selector above.
-    const precisionSelector = page
-      .getByText('Timestamp Precision')
-      .locator('..')
-      .locator('button')
-      .first()
-      .or(
-        page
-          .getByRole('combobox')
-          .filter({ hasText: /Auto-detect|Nanoseconds|Microseconds|Milliseconds|Seconds/ })
-          .first()
-      )
-      .or(
-        page
-          .locator('div')
-          .filter({ hasText: /^Auto-detect$/ })
-          .first()
-      );
-    await expect(precisionSelector.first()).toBeVisible({ timeout: 5000 });
-    await precisionSelector.first().click();
-
-    const secondsOption = page
-      .getByLabel('Select options menu')
-      .getByText('Seconds')
-      .or(page.getByRole('option', { name: /^Seconds$/ }));
-    await expect(secondsOption.first()).toBeVisible({ timeout: 5000 });
-    await secondsOption.first().click();
+    await selectTimestampPrecision(page, 'Seconds');
 
     // The three Line Protocol filter inputs should appear once Line Protocol
     // is selected, and editing each one should run its handler without error.
@@ -98,5 +181,60 @@ test.describe('Kafka Query Editor - Line Protocol Tests', () => {
     await expect(measurementFilter).toHaveValue('Breaker Data');
     await expect(fieldFilter).toHaveValue('PT Primary');
     await expect(tagFilter).toHaveValue('Building=DCM102');
+  });
+
+  test('should stream line protocol data from kafka topic', async ({
+    readProvisionedDataSource,
+    page,
+    panelEditPage,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasource.yaml' });
+    await panelEditPage.datasource.set(ds.name);
+
+    const topic = `lp-stream-${Date.now()}`;
+    const { producer, exitPromise } = startLineProtocolKafkaProducer(topic);
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      await setTableVisualization(panelEditPage);
+
+      await page.getByRole('textbox', { name: 'Enter topic name' }).fill(topic);
+      await page.getByText(topic).click();
+
+      await selectMessageFormat(page, 'Line Protocol');
+      await selectTimestampPrecision(page, 'Seconds');
+
+      const measurementFilter = page.getByLabel('Measurement filter', { exact: true });
+      const fieldFilter = page.getByLabel('Field filter', { exact: true });
+      const tagFilter = page.getByLabel('Tag filter', { exact: true });
+
+      await expect(measurementFilter).toBeVisible({ timeout: 5000 });
+      await expect(fieldFilter).toBeVisible({ timeout: 5000 });
+      await expect(tagFilter).toBeVisible({ timeout: 5000 });
+
+      await measurementFilter.fill('Breaker Data, Last Trip');
+      await fieldFilter.fill('PT Primary, Last trip event Timestamp, Firmware revision, Main capability of device');
+      await tagFilter.fill('Building=DCM102, Device_tag=-XQ202');
+
+      await page.getByRole('button', { name: 'Fetch' }).click();
+
+      await openPartitionSelector(page);
+      await selectAllPartitionsOption(page);
+
+      await verifyColumnHeadersVisible(page, ['Time', '_measurement', '_field']);
+
+      await verifyPanelDataContains(panelEditPage, [
+        /Breaker Data/,
+        /Last Trip/,
+        /PT Primary/,
+        /Last trip event Timestamp/,
+        /XXXXXX/,
+        /MAIN_CAP/,
+      ]);
+    } finally {
+      producer.kill();
+      await Promise.race([exitPromise.catch(() => {}), new Promise((resolve) => setTimeout(resolve, 2000))]);
+    }
   });
 });

--- a/tests/queryEditor-lineprotocol.spec.ts
+++ b/tests/queryEditor-lineprotocol.spec.ts
@@ -1,10 +1,11 @@
 /// <reference types="node" />
 
 import { test, expect } from '@grafana/plugin-e2e';
-import { Locator, Page } from '@playwright/test';
 import { ChildProcess, spawn } from 'child_process';
 import { accessSync, constants } from 'fs';
 import {
+  selectMessageFormat,
+  selectTimestampPrecision,
   openPartitionSelector,
   selectAllPartitionsOption,
   setTableVisualization,
@@ -63,83 +64,6 @@ function startLineProtocolKafkaProducer(topic: string): ProducerHandle {
   });
 
   return { producer, exitPromise };
-}
-
-async function findMessageFormatSelector(page: Page): Promise<Locator | null> {
-  const messageFormatApproaches = [
-    page
-      .locator('div')
-      .filter({ hasText: /^JSON$/ })
-      .nth(2),
-    page.getByText('JSON').locator('../..'),
-    page.locator('.css-1eu65zc').filter({ hasText: /JSON/ }),
-    page.getByText('JSON').filter({ hasText: /^JSON$/ }),
-    page.locator('button').filter({ hasText: /^JSON$/ }),
-    page.getByText('Message Format').locator('..').locator('button').first(),
-    page.locator('[data-testid*="select"]'),
-  ];
-
-  for (const approach of messageFormatApproaches) {
-    if (await approach.isVisible({ timeout: 1000 })) {
-      return approach;
-    }
-  }
-
-  return null;
-}
-
-async function selectMessageFormat(page: Page, optionName: string): Promise<void> {
-  await expect(page.getByText('Message Format')).toBeVisible({ timeout: 5000 });
-
-  const foundSelector = await findMessageFormatSelector(page);
-  expect(foundSelector).not.toBeNull();
-
-  await foundSelector!.first().click();
-
-  const option = page
-    .getByLabel('Select options menu')
-    .getByText(optionName)
-    .or(page.getByRole('option', { name: optionName }));
-  await expect(option.first()).toBeVisible({ timeout: 5000 });
-  await option.first().click();
-}
-
-async function findTimestampPrecisionSelector(page: Page): Promise<Locator | null> {
-  const selectorApproaches = [
-    page.getByText('Timestamp Precision').locator('..').locator('button').first(),
-    page
-      .getByRole('combobox')
-      .filter({ hasText: /Auto-detect|Nanoseconds|Microseconds|Milliseconds|Seconds/ })
-      .first(),
-    page
-      .locator('div')
-      .filter({ hasText: /^Auto-detect$/ })
-      .first(),
-  ];
-
-  for (const approach of selectorApproaches) {
-    if (await approach.isVisible({ timeout: 1000 })) {
-      return approach;
-    }
-  }
-
-  return null;
-}
-
-async function selectTimestampPrecision(page: Page, optionName: string): Promise<void> {
-  await expect(page.getByText('Timestamp Precision')).toBeVisible({ timeout: 5000 });
-
-  const selector = await findTimestampPrecisionSelector(page);
-  expect(selector).not.toBeNull();
-
-  await selector!.first().click();
-
-  const option = page
-    .getByLabel('Select options menu')
-    .getByText(optionName)
-    .or(page.getByRole('option', { name: optionName }));
-  await expect(option.first()).toBeVisible({ timeout: 5000 });
-  await option.first().click();
 }
 
 test.describe.serial('Kafka Query Editor - Line Protocol Tests', () => {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,6 +1,6 @@
 // Shared test utilities for Kafka datasource e2e tests
 import { expect } from '@grafana/plugin-e2e';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import type { PanelEditPage } from '@grafana/plugin-e2e';
 
 /**
@@ -54,6 +54,83 @@ export async function verifyColumnHeadersVisible(page: Page, headers: string[] =
   for (const header of headers) {
     await expect(page.getByRole('columnheader', { name: header })).toBeVisible();
   }
+}
+
+export async function findMessageFormatSelector(page: Page): Promise<Locator | null> {
+  const messageFormatApproaches = [
+    page
+      .locator('div')
+      .filter({ hasText: /^JSON$/ })
+      .nth(2),
+    page.getByText('JSON').locator('../..'),
+    page.locator('.css-1eu65zc').filter({ hasText: /JSON/ }),
+    page.getByText('JSON').filter({ hasText: /^JSON$/ }),
+    page.locator('button').filter({ hasText: /^JSON$/ }),
+    page.getByText('Message Format').locator('..').locator('button').first(),
+    page.locator('[data-testid*="select"]'),
+  ];
+
+  for (const approach of messageFormatApproaches) {
+    if (await approach.isVisible({ timeout: 1000 })) {
+      return approach;
+    }
+  }
+
+  return null;
+}
+
+export async function selectMessageFormat(page: Page, optionName: string): Promise<void> {
+  await expect(page.getByText('Message Format')).toBeVisible({ timeout: 5000 });
+
+  const foundSelector = await findMessageFormatSelector(page);
+  expect(foundSelector).not.toBeNull();
+
+  await foundSelector!.first().click();
+
+  const option = page
+    .getByLabel('Select options menu')
+    .getByText(optionName)
+    .or(page.getByRole('option', { name: optionName }));
+  await expect(option.first()).toBeVisible({ timeout: 5000 });
+  await option.first().click();
+}
+
+export async function findTimestampPrecisionSelector(page: Page): Promise<Locator | null> {
+  const selectorApproaches = [
+    page.getByText('Timestamp Precision').locator('..').locator('button').first(),
+    page
+      .getByRole('combobox')
+      .filter({ hasText: /Auto-detect|Nanoseconds|Microseconds|Milliseconds|Seconds/ })
+      .first(),
+    page
+      .locator('div')
+      .filter({ hasText: /^Auto-detect$/ })
+      .first(),
+  ];
+
+  for (const approach of selectorApproaches) {
+    if (await approach.isVisible({ timeout: 1000 })) {
+      return approach;
+    }
+  }
+
+  return null;
+}
+
+export async function selectTimestampPrecision(page: Page, optionName: string): Promise<void> {
+  await expect(page.getByText('Timestamp Precision')).toBeVisible({ timeout: 5000 });
+
+  const selector = await findTimestampPrecisionSelector(page);
+  expect(selector).not.toBeNull();
+
+  await selector!.first().click();
+
+  const option = page
+    .getByLabel('Select options menu')
+    .getByText(optionName)
+    .or(page.getByRole('option', { name: optionName }));
+  await expect(option.first()).toBeVisible({ timeout: 5000 });
+  await option.first().click();
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for producing and testing Kafka messages in the Line Protocol format within the Go producer and the E2E test suite. The main changes include implementing Line Protocol message generation in `producer.go`, updating the CLI to support this format, and extending the test suite to verify Line Protocol ingestion and UI behavior.

**Line Protocol Support in Kafka Producer:**

* Added a new function `buildLineProtocolMessage` in `producer.go` to construct and return messages in the Line Protocol format.
* Updated the main producer loop to support a `-format lineprotocol` CLI option, generating and sending messages in this format when selected. [[1]](diffhunk://#diff-49eae8a10e9a360ccbf86bc0aca0bf9dbefe9faa1d73f6fc0276e9e7e4dac758L123-R153) [[2]](diffhunk://#diff-49eae8a10e9a360ccbf86bc0aca0bf9dbefe9faa1d73f6fc0276e9e7e4dac758R215-R222) [[3]](diffhunk://#diff-49eae8a10e9a360ccbf86bc0aca0bf9dbefe9faa1d73f6fc0276e9e7e4dac758L199-L201)
* Included the `strings` package import for message formatting.

**Test Suite Enhancements for Line Protocol:**

* Introduced a new E2E test in `queryEditor-lineprotocol.spec.ts` that launches the Go producer in Line Protocol mode, streams data to a topic, and verifies UI and data ingestion in Grafana.
* Refactored test utilities to robustly select message format and timestamp precision in the UI, improving test reliability for Line Protocol and other formats.

**CLI and Validation Updates:**

* Extended the CLI format validation to accept `lineprotocol` as a valid option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating and streaming Influx-style Line Protocol data from the example producer.
  * Added Line Protocol as a selectable message format in the query editor.
  * Added timestamp precision selection, including seconds.
  * Added support for querying Line Protocol data with measurement, field, and tag filters.
* **Tests**
  * Added coverage validating Line Protocol ingestion, querying, partition selection, and displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->