### PR TITLE
chore: use static links for the images in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can automatically configure the Kafka datasource using Grafana's provisionin
    - **Avro Schema Registry** (if using Avro format)
    - **Timeout settings** (default: two seconds)
 
-<a href="src/img/config-basic.png"><img src="src/img/config-basic.png" alt="Kafka basic datasource configuration" width="800"></a>
+<a href="src/img/config-basic.png"><img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png" alt="Kafka basic datasource configuration" width="800"></a>
 
 ### Build the Query
 
@@ -115,7 +115,7 @@ You can automatically configure the Kafka datasource using Grafana's provisionin
 
 **Tip:** Numeric fields become time series, string fields are labels, arrays and nested objects are automatically flattened for visualization.
 
-<img src="src/img/query-json.png" alt="JSON query editor example" width="800">
+<img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/query-json.png" alt="JSON query editor example" width="800">
 
 ## Supported JSON Structures
 
@@ -166,7 +166,7 @@ Avro messages are supported using either:
 - **Inline schema**: paste your Avro schema (JSON format) in the UI
 - **Schema Registry**: the plugin fetches the latest schema by subject from the configured Schema Registry
 
-<img src="src/img/query-avro-inline-schema.png" alt="Avro inline schema editor" width="800">
+<img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/query-avro-inline-schema.png" alt="Avro inline schema editor" width="800">
 
 **Example Avro schema:**
 
@@ -217,12 +217,12 @@ If you encounter issues with complex Protobuf schemas, open an issue so we can p
 
 ## Live Demo
 
-<img src="src/img/graph.gif" alt="Kafka dashboard live demo" width="800">
+<img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/graph.gif" alt="Kafka dashboard live demo" width="800">
 
 More screenshots and recordings (click to open):
 
-- [Streaming dashboard (high-resolution screenshot)](src/img/stream-json-screenshot.png)
-- [Authentication and TLS configuration](src/img/config-authentication.png)
+- [Streaming dashboard (high-resolution screenshot)](https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/stream-json-screenshot.png)
+- [Authentication and TLS configuration](https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-authentication.png)
 
 ## Sample Data Generator
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can automatically configure the Kafka datasource using Grafana's provisionin
    - **Avro Schema Registry** (if using Avro format)
    - **Timeout settings** (default: two seconds)
 
-<a href="src/img/config-basic.png"><img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png" alt="Kafka basic datasource configuration" width="800"></a>
+<a href="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png"><img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png" alt="Kafka basic datasource configuration" width="800"></a>
 
 ### Build the Query
 


### PR DESCRIPTION
This pull request updates image references in the `README.md` to use absolute URLs pointing to the raw images on GitHub instead of relative paths. This ensures that images display correctly when the README is viewed outside the repository (e.g., on npm or other documentation sites).

Documentation improvements:

* Updated all image `src` attributes in `README.md` from relative paths (e.g., `src/img/query-json.png`) to absolute URLs using the `raw.githubusercontent.com` domain, ensuring images render correctly in all contexts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R118) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L169-R169) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L220-R225)
* Updated screenshot and recording links to use absolute URLs for consistent access to images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation images and screenshots to use stable, directly accessible links.
  * Refreshed visuals for datasource configuration, JSON query editing, Avro schema editing, and the live demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->